### PR TITLE
이전 시공순서도 복원

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
                                 </span>
                                 <span class="stat-compact pending">
                                     <i class="fas fa-clock"></i> 
-                                    <span id="pendingSteps">2</span>
+                                    <span id="pendingSteps">9</span>
                                 </span>
                             </div>
                         </div>
@@ -132,6 +132,46 @@
                     
                     <!-- 시공 단계 타임라인 -->
                     <div class="timeline-steps">
+                        <div class="timeline-step" data-step="1" data-name="샤시" data-status="pending">
+                            <div class="step-connector"></div>
+                            <div class="step-content">
+                                <div class="step-badge">
+                                    <div class="step-number">1</div>
+                                    <div class="step-icon"><i class="fas fa-window-maximize"></i></div>
+                                </div>
+                                <div class="step-info">
+                                    <h4 class="step-title">샤시</h4>
+                                    <p class="step-description">창호 프레임 설치 및 유리 삽입</p>
+                                    <div class="step-status-badge" data-status="pending">대기중</div>
+                                </div>
+                                <div class="step-actions">
+                                    <button class="btn-step-manage" onclick="openWorkflowStepModal(circularWorkflow.find(step => step.id === 1))">
+                                        <i class="fas fa-cog"></i> 관리
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        
+                        <div class="timeline-step" data-step="2" data-name="전기" data-status="pending">
+                            <div class="step-connector"></div>
+                            <div class="step-content">
+                                <div class="step-badge">
+                                    <div class="step-number">2</div>
+                                    <div class="step-icon"><i class="fas fa-bolt"></i></div>
+                                </div>
+                                <div class="step-info">
+                                    <h4 class="step-title">전기</h4>
+                                    <p class="step-description">전기 배선 및 기초 공사</p>
+                                    <div class="step-status-badge" data-status="pending">대기중</div>
+                                </div>
+                                <div class="step-actions">
+                                    <button class="btn-step-manage" onclick="openWorkflowStepModal(circularWorkflow.find(step => step.id === 2))">
+                                        <i class="fas fa-cog"></i> 관리
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        
                         <div class="timeline-step" data-step="3" data-name="문" data-status="pending">
                             <div class="step-connector"></div>
                             <div class="step-content">
@@ -166,6 +206,106 @@
                                 </div>
                                 <div class="step-actions">
                                     <button class="btn-step-manage" onclick="openWorkflowStepModal(circularWorkflow.find(step => step.id === 4))">
+                                        <i class="fas fa-cog"></i> 관리
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        
+                        <div class="timeline-step" data-step="5" data-name="목공" data-status="pending">
+                            <div class="step-connector"></div>
+                            <div class="step-content">
+                                <div class="step-badge">
+                                    <div class="step-number">5</div>
+                                    <div class="step-icon"><i class="fas fa-hammer"></i></div>
+                                </div>
+                                <div class="step-info">
+                                    <h4 class="step-title">목공</h4>
+                                    <p class="step-description">목재 가구 및 인테리어 설치</p>
+                                    <div class="step-status-badge" data-status="pending">대기중</div>
+                                </div>
+                                <div class="step-actions">
+                                    <button class="btn-step-manage" onclick="openWorkflowStepModal(circularWorkflow.find(step => step.id === 5))">
+                                        <i class="fas fa-cog"></i> 관리
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        
+                        <div class="timeline-step" data-step="6" data-name="타일" data-status="pending">
+                            <div class="step-connector"></div>
+                            <div class="step-content">
+                                <div class="step-badge">
+                                    <div class="step-number">6</div>
+                                    <div class="step-icon"><i class="fas fa-th-large"></i></div>
+                                </div>
+                                <div class="step-info">
+                                    <h4 class="step-title">타일</h4>
+                                    <p class="step-description">기존 타일 철거 및 신규 타일 시공</p>
+                                    <div class="step-status-badge" data-status="pending">대기중</div>
+                                </div>
+                                <div class="step-actions">
+                                    <button class="btn-step-manage" onclick="openWorkflowStepModal(circularWorkflow.find(step => step.id === 6))">
+                                        <i class="fas fa-cog"></i> 관리
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        
+                        <div class="timeline-step" data-step="7" data-name="벽지+바닥" data-status="pending">
+                            <div class="step-connector"></div>
+                            <div class="step-content">
+                                <div class="step-badge">
+                                    <div class="step-number">7</div>
+                                    <div class="step-icon"><i class="fas fa-paint-roller"></i></div>
+                                </div>
+                                <div class="step-info">
+                                    <h4 class="step-title">벽지+바닥</h4>
+                                    <p class="step-description">벽지 도배 및 바닥재 시공</p>
+                                    <div class="step-status-badge" data-status="pending">대기중</div>
+                                </div>
+                                <div class="step-actions">
+                                    <button class="btn-step-manage" onclick="openWorkflowStepModal(circularWorkflow.find(step => step.id === 7))">
+                                        <i class="fas fa-cog"></i> 관리
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        
+                        <div class="timeline-step" data-step="8" data-name="전기 마감" data-status="pending">
+                            <div class="step-connector"></div>
+                            <div class="step-content">
+                                <div class="step-badge">
+                                    <div class="step-number">8</div>
+                                    <div class="step-icon"><i class="fas fa-bolt"></i></div>
+                                </div>
+                                <div class="step-info">
+                                    <h4 class="step-title">전기 마감</h4>
+                                    <p class="step-description">조명 및 전기기구 최종 설치</p>
+                                    <div class="step-status-badge" data-status="pending">대기중</div>
+                                </div>
+                                <div class="step-actions">
+                                    <button class="btn-step-manage" onclick="openWorkflowStepModal(circularWorkflow.find(step => step.id === 8))">
+                                        <i class="fas fa-cog"></i> 관리
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        
+                        <div class="timeline-step" data-step="9" data-name="입주청소" data-status="pending">
+                            <div class="step-connector"></div>
+                            <div class="step-content">
+                                <div class="step-badge">
+                                    <div class="step-number">9</div>
+                                    <div class="step-icon"><i class="fas fa-broom"></i></div>
+                                </div>
+                                <div class="step-info">
+                                    <h4 class="step-title">입주청소</h4>
+                                    <p class="step-description">최종 청소 및 정리</p>
+                                    <div class="step-status-badge" data-status="pending">대기중</div>
+                                </div>
+                                <div class="step-actions">
+                                    <button class="btn-step-manage" onclick="openWorkflowStepModal(circularWorkflow.find(step => step.id === 9))">
                                         <i class="fas fa-cog"></i> 관리
                                     </button>
                                 </div>

--- a/script.js
+++ b/script.js
@@ -26,8 +26,15 @@ let memos = [];
 
 // 원형 워크플로우 데이터 구조
 let circularWorkflow = [
+    { id: 1, name: "샤시", icon: "window-maximize", status: "pending", progress: 0, details: "", contractors: [], images: [] },
+    { id: 2, name: "전기", icon: "bolt", status: "pending", progress: 0, details: "", contractors: [], images: [] },
     { id: 3, name: "문", icon: "door-closed", status: "pending", progress: 0, details: "", contractors: [], images: [] },
-    { id: 4, name: "바닥 수평", icon: "ruler-horizontal", status: "pending", progress: 0, details: "", contractors: [], images: [] }
+    { id: 4, name: "바닥 수평", icon: "ruler-horizontal", status: "pending", progress: 0, details: "", contractors: [], images: [] },
+    { id: 5, name: "목공", icon: "hammer", status: "pending", progress: 0, details: "", contractors: [], images: [] },
+    { id: 6, name: "타일", icon: "border-all", status: "pending", progress: 0, details: "", contractors: [], images: [] },
+    { id: 7, name: "벽지+바닥", icon: "paint-roller", status: "pending", progress: 0, details: "", contractors: [], images: [] },
+    { id: 8, name: "전기 마감", icon: "plug", status: "pending", progress: 0, details: "", contractors: [], images: [] },
+    { id: 9, name: "입주청소", icon: "broom", status: "pending", progress: 0, details: "", contractors: [], images: [] }
 ];
 
 // 기본 워크플로우 백업: Firebase 데이터 누락 시 병합/복구용


### PR DESCRIPTION
Restore the construction sequence diagram to its previous 9-step state.

This PR reverts a previous change that reduced the construction sequence diagram from 9 steps to 2, bringing back all original workflow stages as requested by the user.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-9f85e924-3465-4aea-9a10-fb56c7433c4d) · [Cursor](https://cursor.com/background-agent?bcId=bc-9f85e924-3465-4aea-9a10-fb56c7433c4d)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)